### PR TITLE
fix 現時点で複数のページにおける不足していたリンクの追加

### DIFF
--- a/static/articles/articles.css
+++ b/static/articles/articles.css
@@ -2,6 +2,16 @@ li {
     list-style: none;
 }
 
+a {
+    color: grey;
+    text-decoration: none;
+}
+
+a:hover {
+    color: grey;
+    text-decoration: none;
+}
+
 .search-form {
     margin-top: 2.5%;
     margin-left: 57.5px;
@@ -19,11 +29,6 @@ li {
 
 .article li {
     margin-left: 15px;
-}
-
-.article-title a {
-    color: grey;
-    text-decoration: none;
 }
 
 .pagination {

--- a/templates/articles/article.html
+++ b/templates/articles/article.html
@@ -12,8 +12,8 @@
                 <li><img src="/media/{{ article.author.icon }}" style="border-radius: 50px; width: 50px; height: 50px;"></li>
                 <li><b>ユーザ名:</b> <a href="{% url 'users:articles' article.author.username %}">{{ article.author.username }}</a></li>
                 <li><b>プロフィール:</b> <br>{{ article.author.profile_message }}</li>
-                <li class="relation"><b> Follow </b> <br> {{ article.author.followees.all|length }} </li>
-                <li class="relation"><b> Follower</b> <br> {{ article.author.followers.all|length }} </li>
+                <li class="relation"><a href="{% url 'users:followees' article.author.username %}"><b> Follow </b></a><br> {{ article.author.followees.all|length }} </li>
+                <li class="relation"><a href="{% url 'users:followers' article.author.username %}"><b> Follow </b></a><br> {{ article.author.followers.all|length }} </li>
             </ul>
         </div>
 

--- a/templates/articles/articles.html
+++ b/templates/articles/articles.html
@@ -21,7 +21,7 @@
         <ul>
             {% for article in article_list %}
                 <ul class="article">
-                    <li class="author-info"><img src='/media/{{ article.author.icon }}' style='border-radius: 50px; width: 25px; height: 25px;'> {{ article.author.username }}が{{ article.create_date }}に投稿</li>
+                    <li class="author-info"><img src='/media/{{ article.author.icon }}' style='border-radius: 50px; width: 25px; height: 25px;'> <a href="{% url 'users:articles' article.author.username %}">{{ article.author.username }}</a>が{{ article.create_date }}に投稿</li>
                     <li class="article-title"><a href='{% url "articles:article" article.pk %}'> {{ article.title }} </a></li>
                     <li class="article-content">{{ article.content|slice:":30" }} ... </li>
                 </ul>

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -16,7 +16,7 @@
     <body>
         <header>
             <nav class="navbar navbar-expand-lg navbar-light bg-light">
-                <a class="navbar-brand" href="#">simple blog</a>
+                <a class="navbar-brand" href="{% url 'articles:articles' %}">simple blog</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>

--- a/templates/users/favorites.html
+++ b/templates/users/favorites.html
@@ -20,7 +20,7 @@
             <ul>
                 {% for article in article_list %}
                     <ul class="article">
-                        <li class="author-info"><img src='/media/{{ user.icon }}' style='border-radius: 50px; width: 25px; height: 25px;'><a href="{% url 'users:articles' article.author %}">{{ article.author }}</a>が{{ article.create_date }}に投稿</li>
+                        <li class="author-info"><img src='/media/{{ article.author.icon }}' style='border-radius: 50px; width: 25px; height: 25px;'><a href="{% url 'users:articles' article.author %}">{{ article.author }}</a>が{{ article.create_date }}に投稿</li>
                         <li class="article-title"><a href='{% url "articles:article" article.pk %}'> {{ article.title }} </a></li>
                         <li class="article-content">{{ article.content|slice:":30" }} ... </li>
                     </ul>


### PR DESCRIPTION
ヘッダのsimple blogに記事一覧ページへのリンクを追加
記事一覧ページの投稿者名からその投稿者のプロフィールページへのリンクの追加
記事ページのフォロー・フォロワーからその記事の投稿者のフォロー・フォロワーリストへのリンクの追加
プロフィールのお気に入り記事一覧の投稿者のアイコンのURLが間違っていたので修正