### PR TITLE
fix プロフィールメッセージを100文字までにして折り畳む様にした

### DIFF
--- a/static/articles/article.css
+++ b/static/articles/article.css
@@ -27,6 +27,10 @@ a:hover {
     background-color: #fafafa;
 }
 
+.article-author-profile .profile_message {
+    word-break : break-all;
+}
+
 .article-author-profile li.relation {
     padding-right: 1%;
     float: left;

--- a/static/users/base.css
+++ b/static/users/base.css
@@ -36,6 +36,10 @@ a:hover {
     background-color: #fafafa;
 }
 
+.user-profile1 .profile_message {
+    word-break : break-all;
+}
+
 .user-profile2 {
     margin-top: 12.5%;
     padding-top: 7.25%;

--- a/templates/articles/article.html
+++ b/templates/articles/article.html
@@ -11,7 +11,7 @@
             <ul>
                 <li><img src="/media/{{ article.author.icon }}" style="border-radius: 50px; width: 50px; height: 50px;"></li>
                 <li><b>ユーザ名:</b> <a href="{% url 'users:articles' article.author.username %}">{{ article.author.username }}</a></li>
-                <li><b>プロフィール:</b> <br>{{ article.author.profile_message }}</li>
+                <li class="profile_message"><b>プロフィール:</b> <br>{{ article.author.profile_message|slice:":100" }} ...</li>
                 <li class="relation"><a href="{% url 'users:followees' article.author.username %}"><b> Follow </b></a><br> {{ article.author.followees.all|length }} </li>
                 <li class="relation"><a href="{% url 'users:followers' article.author.username %}"><b> Follow </b></a><br> {{ article.author.followers.all|length }} </li>
             </ul>

--- a/templates/users/base.html
+++ b/templates/users/base.html
@@ -18,7 +18,7 @@
             </form>
             {% endif %}
 
-            <li><b>プロフィール:</b> <br>{{ profile_user.profile_message|slice:":30" }}</li>
+            <li class="profile_message"><b>プロフィール:</b> <br>{{ profile_user.profile_message|slice:":100" }}...</li>
             <li class="relation"><a href="{% url 'users:followees' profile_user.username %}"><b>Follow</b></a> <br> {{ profile_user.followees.all|length }} </li>
             <li class="relation"><a href="{% url 'users:followers' profile_user.username %}"><b>Follower</b></a> <br> {{ profile_user.followers.all|length }} </li>
         </ul>


### PR DESCRIPTION
記事ページとプロフィールページのプロフィールメッセージを100文字まで表示する様にして,折り畳む様に変更した