### PR TITLE
fix 記事の編集ページにおいて存在しない記事IDを選択された場合に404を返す様に修正

### DIFF
--- a/settings/tests.py
+++ b/settings/tests.py
@@ -644,6 +644,14 @@ class UpdateArticleViewTest(TestCase):
                                            kwargs={'pk': article.pk}))
         self.assertEquals(response.status_code, 302)
 
+    # ログインをしている状態で存在しない記事のページへアクセスする事が出来ない
+    def test_fail_access_notexist(self):
+        self.client.login(username='updatearticleview_tester2',
+                          password='postarticle0123')
+        response = self.client.get(reverse('settings:updatearticle',
+                                           kwargs={'pk': 1000}))
+        self.assertEquals(response.status_code, 404)
+
     # ログインしているユーザが作成していない記事のページへアクセスする事が出来ない
     def test_fail_access_notauthor(self):
         self.client.login(username='updatearticleview_tester2',

--- a/settings/views.py
+++ b/settings/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.views import PasswordChangeView
 from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.views.generic import UpdateView, ListView, CreateView
 
@@ -109,7 +110,7 @@ class PostedArticleListView(LoginRequiredMixin, ListView):
         return self.model.objects.filter(author=self.request.user)
 
 
-class OnlyAuthorMxin(UserPassesTestMixin):
+class OnlyAuthorMixin(UserPassesTestMixin):
     """
     記事の編集ページを作者のみがアクセスするためのMixin
     """
@@ -117,14 +118,15 @@ class OnlyAuthorMxin(UserPassesTestMixin):
     def test_func(self):
         user = self.request.user
 
-        article = Article.objects.filter(pk=self.kwargs['pk']).select_related('author').get()
+        article = get_object_or_404(Article.objects.filter(pk=self.kwargs['pk']).select_related('author'),
+                                    pk=self.kwargs['pk'])
         if article.author == user:
             return True
 
         return False
 
 
-class UpdateArticleView(LoginRequiredMixin, OnlyAuthorMxin, UpdateView):
+class UpdateArticleView(LoginRequiredMixin, OnlyAuthorMixin, UpdateView):
     model = Article
     form_class = UpdateArticleForm
     template_name = 'settings/update_article.html'


### PR DESCRIPTION
# 修正点

- OnlyAuthorMixinにおいて記事モデルを取得する際にget_object_or_404()を利用する事で存在しない記事を指定された場合は404を返す様に修正
- また上記の処理を確認するためのユニットテストが不足していたので作成し,検証を行った