### PR TITLE
fix 記事編集ページと新規記事ページのフォームを共通のフォームに変更した

### DIFF
--- a/settings/forms.py
+++ b/settings/forms.py
@@ -40,7 +40,7 @@ class UpdatePasswordForm(PasswordChangeForm):
             field.widget.attrs['placeholder'] = field.label
 
 
-class CreateArticleForm(forms.ModelForm):
+class ArticleForm(forms.ModelForm):
     tags = forms.ModelMultipleChoiceField(queryset=Tag.objects.all(),
                                           widget=forms.CheckboxSelectMultiple,
                                           required=True)
@@ -54,21 +54,6 @@ class CreateArticleForm(forms.ModelForm):
         self.fields['title'].widget.attrs['class'] = 'form-control'
         self.fields['content'].widget.attrs['class'] = 'form-control'
         self.fields['tags'].widget.attrs['class'] = 'mt-2 mb-3 font-weight-normal'
-
-
-class UpdateArticleForm(forms.ModelForm):
-    tags = forms.ModelMultipleChoiceField(queryset=Tag.objects.all(),
-                                          widget=forms.CheckboxSelectMultiple,
-                                          required=True)
-
-    class Meta:
-        model = Article
-        fields = ['title', 'content', 'tags']
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        for field in self.fields.values():
-            field.widget.attrs['class'] = 'mt-2 mb-3 font-weight-normal'
 
 
 class UpdateProfileForm(forms.ModelForm):

--- a/settings/tests.py
+++ b/settings/tests.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 from PIL import Image
 
 from .forms import UpdateUsernameForm, UpdateEmailForm, UpdatePasswordForm, \
-    CreateArticleForm, UpdateArticleForm, UpdateProfileForm
+    ArticleForm, UpdateProfileForm
 from authenticate.models import Relation
 from articles.models import Article, Tag
 
@@ -416,7 +416,7 @@ class DeleteUserViewTest(TestCase):
             User.objects.get(username='delete_user_view')
 
 
-class CreateArticleFormTest(TestCase):
+class ArticleFormTest(TestCase):
     @classmethod
     def setUpClass(cls):
         Tag.objects.create(tag='post_article_post_test')
@@ -431,7 +431,7 @@ class CreateArticleFormTest(TestCase):
             'tags': [article_tag]
         }
 
-        form = CreateArticleForm(data=article_data)
+        form = ArticleForm(data=article_data)
         self.assertTrue(form.is_valid())
 
     # 誤った形式のタイトル・記事内容は妥当でない
@@ -457,7 +457,7 @@ class CreateArticleFormTest(TestCase):
         ]
 
         for wrong_format_data in wrong_format_data_list:
-            form = CreateArticleForm(data=wrong_format_data)
+            form = ArticleForm(data=wrong_format_data)
             self.assertFalse(form.is_valid())
 
 
@@ -584,49 +584,6 @@ class PostedArticleListView(TestCase):
         response = self.client.get(''.join([reverse('settings:postedarticles'),
                                             '?', urlencode(dict(page='6'))]))
         self.assertEqual(response.status_code, 404)
-
-
-class UpdateArticlePostFormTest(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        Tag.objects.create(tag='update_article_post_tester')
-        return super().setUpClass()
-
-    # 正しいタイトル・記事内容は妥当である
-    def test_valid_form(self):
-        article_tag = Tag.objects.get(tag='update_article_post_tester')
-        article_data = {
-            'title': 'A' * 1000,
-            'content': 'A' * 10000,
-            'tags': [article_tag]
-        }
-        form = UpdateArticleForm(data=article_data)
-        self.assertTrue(form.is_valid())
-
-    # 誤った形式のタイトル・記事内容は妥当でない
-    def test_invalid_wrongformat(self):
-        article_tag = Tag.objects.get(tag='update_article_post_tester')
-        wrong_format_data_list = [
-            {
-                'title': 'A' * 1001,
-                'content': 'sample_content',
-                'tags': [article_tag]
-            },
-            {
-                'title': 'A' * 1000,
-                'content': 'A' * 10001,
-                'tags': [article_tag]
-            },
-            {
-                'title': 'A' * 1001,
-                'content': 'A' * 10001,
-                'tags': []
-            }
-        ]
-
-        for wrong_format_data in wrong_format_data_list:
-            form = UpdateArticleForm(data=wrong_format_data)
-            self.assertFalse(form.is_valid())
 
 
 @override_settings(AXES_ENABLED=False)

--- a/settings/views.py
+++ b/settings/views.py
@@ -7,7 +7,7 @@ from django.urls import reverse_lazy
 from django.views.generic import UpdateView, ListView, CreateView, DeleteView
 
 from .forms import UpdateUsernameForm, UpdateEmailForm, UpdatePasswordForm, \
-    CreateArticleForm, UpdateArticleForm, UpdateProfileForm
+    ArticleForm, UpdateProfileForm
 from users.forms import FollowForm
 from authenticate.models import Relation
 from articles.models import Article
@@ -99,7 +99,7 @@ class DeleteUserView(LoginRequiredMixin, DeleteView):
 
 class CreateArticleView(LoginRequiredMixin, CreateView):
     template_name = 'settings/newarticle.html'
-    form_class = CreateArticleForm
+    form_class = ArticleForm
     model = Article
     success_url = reverse_lazy('settings:username')
 
@@ -138,7 +138,7 @@ class OnlyAuthorMixin(UserPassesTestMixin):
 
 class UpdateArticleView(LoginRequiredMixin, OnlyAuthorMixin, UpdateView):
     model = Article
-    form_class = UpdateArticleForm
+    form_class = ArticleForm
     template_name = 'settings/update_article.html'
     success_url = reverse_lazy('settings:postedarticles')
 


### PR DESCRIPTION
# 修正点

- UpdateArticleFormとCreateArticleFormは同じなので,ArticleFormに共通化させた
- 上記の変更に伴いViewで指定しているフォームの変更とユニットテストの変更を行った